### PR TITLE
Add art events page

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,20 @@
+- title: "Brussels Gallery Weekend"
+  date: 2024-09-05
+  location: "Various Galleries"
+  description: "Annual opening of the contemporary art season with exhibitions and tours."
+- title: "Art Brussels Fair"
+  date: 2025-04-20
+  location: "Brussels Expo"
+  description: "Major international art fair showcasing modern and contemporary works."
+- title: "Comic Art Expo"
+  date: 2024-11-12
+  location: "Tour & Taxis"
+  description: "Celebration of comic book artists with workshops and signings."
+- title: "Night of the Museums"
+  date: 2024-12-07
+  location: "City-wide"
+  description: "Museums open late with special performances and activities."
+- title: "Digital Arts Festival"
+  date: 2025-02-15
+  location: "Bozar"
+  description: "Exploration of digital art, VR experiences, and new media installations."

--- a/events.md
+++ b/events.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: "Brussels Art Events"
+---
+
+# Brussels Art Events
+
+Below is a list of upcoming art events in Brussels. To update this page, edit the file `_data/events.yml` in the repository and commit your changes.
+
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Event</th>
+      <th>Location</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for event in site.data.events %}
+    <tr>
+      <td>{{ event.date | date: "%B %-d, %Y" }}</td>
+      <td>{{ event.title }}</td>
+      <td>{{ event.location }}</td>
+      <td>{{ event.description }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+## Calendar
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=Europe%2FBrussels&src=fakecalendar%40example.com&color=%230F4B8E&mode=AGENDA" style="border:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+<p>Edit the calendar URL above to link your own public calendar.</p>

--- a/index.md
+++ b/index.md
@@ -4,8 +4,8 @@ title: "Fabrice Van Boeckel"
 ---
 
 # Fabrice Van Boeckel
-**Statistician / Data Scientist**  
-Luxembourg and Belgium  
+**Statistician / Data Scientist**
+Luxembourg and Belgium
 [Email](mailto:fabricevb@hotmail.com) • [GitHub](https://github.com/fabricevb) • [LinkedIn](https://www.linkedin.com/in/fabricevb/)
 
 ---
@@ -22,4 +22,4 @@ I am passionate about turning complex data into clear, actionable insights. My e
 ## Looking for new opportunities
 Interested in leveraging data to drive results? Let's connect!
 
-[About Me](about.html) | [Portfolio](portfolio.html)
+[About Me](about.html) | [Portfolio](portfolio.html) | [Art Events](events.html)


### PR DESCRIPTION
## Summary
- add events data in `_data/events.yml`
- create `events.md` page rendering events and a calendar iframe
- link to the new page from `index.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68679c327f10832fb5824e674ef6c1ab